### PR TITLE
Add multi upload tab to be compatible with new_find dialog changes

### DIFF
--- a/templates/_media_upload_panel.tpl
+++ b/templates/_media_upload_panel.tpl
@@ -1,0 +1,16 @@
+{% extends "_action_dialog_media_upload_tab_upload.tpl" %}
+
+{% block upload_form %}
+    {% if id or not m.acl.is_allowed.use.mod_admin_multiupload %}
+        {# replacing medium #}
+        {% inherit %}
+    {% else %}
+        <div class="tab-pane {% if is_active %}active{% endif %}" id="{{ tab }}-multi">
+            {% include "_admin_multiupload.tpl"
+                       subject_id=subject_id
+                       predicate=predicate|default:`depiction`
+                       is_dialog
+            %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/_media_upload_tab.tpl
+++ b/templates/_media_upload_tab.tpl
@@ -1,0 +1,3 @@
+<li {% if tab == "multi" %}class="active"{% endif %}>
+    <a data-toggle="tab" href="#{{ tab }}-multi">{_ Multi upload _}</a>
+</li>


### PR DESCRIPTION
Since the new_find dialog changes the multi upload tab wasn't usable anymore, since it used the upload tab. If we leave the old template files it is still compatible with older zotonic versions. 

Perhaps in the future we could merge this with the new_find dialog, for now this works. 